### PR TITLE
Fixed cyclic dependency STL's libc wrapper and _builtin

### DIFF
--- a/files/stl03.modulemap
+++ b/files/stl03.modulemap
@@ -16,7 +16,8 @@ module stl03 [system] {
   module "cstdarg" { header "cstdarg" export * } // Handling of variable length argument lists
   module "cstddef" { header "cstddef" export * } // typedefs for types such as size_t, NULL and others
   module "cstdio" { header "cstdio" export * } //  C-style input-output functions
-  module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
+  // Removed to fix cyclic dependencies between clang's builtin module and this module.
+  //module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
   module "cstring" { header "cstring" export * } // various narrow character string handling functions
   module "ctime" { header "ctime" export * } // C-style time/date utilites
   module "cwchar" { header "cwchar" export * } //  various wide and multibyte string handling functions

--- a/files/stl11.modulemap
+++ b/files/stl11.modulemap
@@ -24,7 +24,8 @@ module stl11 [system] {
   module "cstddef" { header "cstddef" export * } // typedefs for types such as size_t, NULL and others
   module "cstdint" { header "cstdint" export * } // (since C++11) fixed-size types and limits of other types
   module "cstdio" { header "cstdio" export * } //  C-style input-output functions
-  module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
+  // Removed to fix cyclic dependencies between clang's builtin module and this module.
+  //module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
   module "cstring" { header "cstring" export * } // various narrow character string handling functions
   module "ctime" { header "ctime" export * } // C-style time/date utilites
   module "cuchar" { header "cuchar" export * } // (since C++11)  C-style Unicode character conversion functions

--- a/files/stl14.modulemap
+++ b/files/stl14.modulemap
@@ -25,7 +25,8 @@ module stl14 [system] {
   module "cstddef" { header "cstddef" export * } // typedefs for types such as size_t, NULL and others
   module "cstdint" { header "cstdint" export * } // (since C++11) fixed-size types and limits of other types
   module "cstdio" { header "cstdio" export * } //  C-style input-output functions
-  module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
+  // Removed to fix cyclic dependencies between clang's builtin module and this module.
+  //module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
   module "cstring" { header "cstring" export * } // various narrow character string handling functions
   module "ctime" { header "ctime" export * } // C-style time/date utilites
   module "cuchar" { header "cuchar" export * } // (since C++11)  C-style Unicode character conversion functions

--- a/files/stl17.modulemap
+++ b/files/stl17.modulemap
@@ -24,7 +24,8 @@ module stl17 [system] {
   module "cstddef" { header "cstddef" export * } // typedefs for types such as size_t, NULL and others
   module "cstdint" { header "cstdint" export * } // (since C++11) fixed-size types and limits of other types
   module "cstdio" { header "cstdio" export * } //  C-style input-output functions
-  module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
+  // Removed to fix cyclic dependencies between clang's builtin module and this module.
+  //module "cstdlib" { header "cstdlib" export * } // General purpose utilities: program control, dynamic memory allocation, random numbers, sort and search
   module "cstring" { header "cstring" export * } // various narrow character string handling functions
   module "ctime" { header "ctime" export * } // C-style time/date utilites
   module "cuchar" { header "cuchar" export * } // (since C++11)  C-style Unicode character conversion functions


### PR DESCRIPTION
It seems that having cstdlib in a module will cause a cyclic dependency
between the clang builtin module and our STL module. let's remove the
stdlib.h compability header from the module which should fix this.